### PR TITLE
Update mixins.py

### DIFF
--- a/drf_psq/mixins.py
+++ b/drf_psq/mixins.py
@@ -114,10 +114,13 @@ class PsqMixin(object):
     def check_object_permissions(self, *args, **kwargs):
         if self.action == 'metadata':
             super().check_object_permissions(*args, **kwargs)
+            return
 
         view = self._psq_get_view()
         if not self._psq_check(view):
             super().check_object_permissions(*args, **kwargs)
+            return
 
         if get_caller_name() != self.get_object.__name__:
             super().check_object_permissions(*args, **kwargs)
+            return


### PR DESCRIPTION
we should break in function check_object_permissions where self.action is metadata  just like in function get_queryset.
otherwise, it will raise an exception while calling self._psq_get_view() which is in the next line 